### PR TITLE
New amount for the weekly Patterns within patterns

### DIFF
--- a/fluxRewards.js
+++ b/fluxRewards.js
@@ -12,7 +12,7 @@ let fluxRewards = {
     // Zereth Mortis
     'rares': '50-75',
     'dailies': 75,
-    'weeklies': 150,
+    'weeklies': 400,
     'repeatableTreasures': "10-14",
     'dailyTreasure': 75,
     'bigTreasure': 200


### PR DESCRIPTION
The Quest changed from a 3-day quest to weekly.
https://www.wowhead.com/news/patterns-within-patterns-zereth-mortis-quest-changing-to-weekly-duration-on-next-326105
Old quest: https://www.wowhead.com/quest=65324/patterns-within-patterns
New quest: https://www.wowhead.com/quest=66042/patterns-within-patterns
Rewards 400 now